### PR TITLE
Fix type mismatch of local repository argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ async fn main() -> Result<()> {
             Arg::new(LOCAL_REPO_NAME)
                 .short('r')
                 .long("repository")
-                .value_parser(value_parser!(PathBuf))
+                .value_parser(NonEmptyStringValueParser::new())
                 .help("Path to a local repository to detect the appropriate remote host")
                 .default_value("."),
         )


### PR DESCRIPTION
I was getting the following error while trying to run `repofetch`:

```
thread 'main' panicked at 'Mismatch between definition and access of `local repository`. Could not downcast to alloc::string::String, need to downcast to std::path::PathBuf
', src/main.rs:119:55
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This happens because `LOCAL_REPO_NAME` argument was defined to be parsed as `PathBuf`:

https://github.com/spenserblack/repofetch/blob/c7bff1d51db78aa1906a16ebefc8bfbfb6b204df/src/main.rs#L73

However, the value is retrieved as `String`:

https://github.com/spenserblack/repofetch/blob/c7bff1d51db78aa1906a16ebefc8bfbfb6b204df/src/main.rs#L119

This PR updates the `value_parser` of `LOCAL_REPO_NAME` thus fixes the mismatch error.

