### PR TITLE
Update to Rust 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "repofetch"
 version = "0.3.2"
 authors = ["Spenser Black <spenserblack01@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Fetch details about your remote repository"
 readme = "README.md"


### PR DESCRIPTION
This PR updates the codebase to Rust edition 2021.

See: https://doc.rust-lang.org/edition-guide/rust-2021/index.html
