### PR TITLE
Make `.git` remote url suffix optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixed
 
 - Crash caused by `-r`/`--repository` type mismatch
+- GitHub repository names not being detected when they didn't have the optional
+  `.git` suffix
 
 ## [0.3.2]
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -277,16 +277,6 @@ mod tests {
         };
     }
 
-    macro_rules! failing_repo_from_remote {
-        ($name:ident, $url:literal) => {
-            #[test]
-            fn $name() {
-                let result = repo_from_remote($url);
-                assert!(result.is_err());
-            }
-        };
-    }
-
     passing_repo_from_remote!(http, "http://github.com/owner/repo.git", "owner", "repo");
     passing_repo_from_remote!(https, "https://github.com/owner/repo.git", "owner", "repo");
     passing_repo_from_remote!(
@@ -303,7 +293,4 @@ mod tests {
         "us3r-nam3",
         "r3p0-with.special"
     );
-
-    failing_repo_from_remote!(https_bad_suffix, "https://github.com/owner/repo.goat");
-    failing_repo_from_remote!(ssh_bad_suffix, "git@github.com:owner/repo.goat");
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -10,16 +10,16 @@ use octocrab::OctocrabBuilder;
 use regex::Regex;
 
 lazy_static! {
-    static ref GITHUB_RE: Regex = Regex::new(r"(?:(?:git@github\.com:)|(?:https?://github\.com/))(?P<owner>[\w\.\-]+)/(?P<repository>[\w\.\-]+)\.git").unwrap();
+    static ref GITHUB_RE: Regex = Regex::new(r"(?:(?:git@github\.com:)|(?:https?://github\.com/))(?P<owner>[\w\.\-]+)/(?P<repository>[\w\.\-]+)").unwrap();
 }
 
 /// Creates an `owner/repo` tuple from a GitHub URL.
 pub(crate) fn repo_from_remote(remote: &str) -> Result<(String, String)> {
     let captures = GITHUB_RE.captures(remote).context("no GitHub match")?;
-    Ok((
-        captures.name("owner").unwrap().as_str().into(),
-        captures.name("repository").unwrap().as_str().into(),
-    ))
+    let owner = captures.name("owner").unwrap().as_str();
+    let repository = captures.name("repository").unwrap().as_str();
+    let repository = repository.strip_suffix(".git").unwrap_or(repository);
+    Ok((owner.into(), repository.into()))
 }
 
 pub(crate) async fn main(owner: &str, repo: &str, config: RepofetchConfig) -> Result<()> {

--- a/src/github.rs
+++ b/src/github.rs
@@ -277,13 +277,33 @@ mod tests {
         };
     }
 
+    macro_rules! failing_repo_from_remote {
+        ($name:ident, $url:literal) => {
+            #[test]
+            fn $name() {
+                let result = repo_from_remote($url);
+                assert!(result.is_err());
+            }
+        };
+    }
+
     passing_repo_from_remote!(http, "http://github.com/owner/repo.git", "owner", "repo");
     passing_repo_from_remote!(https, "https://github.com/owner/repo.git", "owner", "repo");
+    passing_repo_from_remote!(
+        https_no_suffix,
+        "https://github.com/owner/repo",
+        "owner",
+        "repo"
+    );
     passing_repo_from_remote!(ssh, "git@github.com:owner/repo.git", "owner", "repo");
+    passing_repo_from_remote!(ssh_no_suffix, "git@github.com:owner/repo", "owner", "repo");
     passing_repo_from_remote!(
         complex_url,
         "https://github.com/us3r-nam3/r3p0-with.special.git",
         "us3r-nam3",
         "r3p0-with.special"
     );
+
+    failing_repo_from_remote!(https_bad_suffix, "https://github.com/owner/repo.goat");
+    failing_repo_from_remote!(ssh_bad_suffix, "git@github.com:owner/repo.goat");
 }


### PR DESCRIPTION
For GitHub, the `.git` suffix is optional for the remote URL.

Fixes #181
