### PR TITLE
Fix CI breaking at setup-ruby

### DIFF
--- a/repofetch.gemspec
+++ b/repofetch.gemspec
@@ -3,8 +3,6 @@
 LONG_DESCRIPTION = 'A plugin-based tool to fetch stats, with a GitHub stat fetcher included by default'
 
 Gem::Specification.new do |spec|
-  require 'rake'
-
   spec.name                               = 'repofetch'
   spec.version                            = '0.4.0'
   spec.authors                            = ['Spenser Black']
@@ -20,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri']           = spec.homepage
   spec.metadata['source_code_uri']        = 'https://github.com/spenserblack/repofetch'
 
-  spec.files                              = FileList['lib/**/*', 'exe/*', '[A-Z]*'].to_a
+  spec.files                              = Dir['lib/**/*'] + Dir['exe/*'] + Dir['[A-Z]*']
 
   spec.bindir                             = 'exe'
   spec.executables                        = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/repofetch.gemspec
+++ b/repofetch.gemspec
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'rake'
-
 LONG_DESCRIPTION = 'A plugin-based tool to fetch stats, with a GitHub stat fetcher included by default'
 
 Gem::Specification.new do |spec|
+  require 'rake'
+
   spec.name                               = 'repofetch'
   spec.version                            = '0.4.0'
   spec.authors                            = ['Spenser Black']


### PR DESCRIPTION
`setup-ruby` is failing because `bundle install` couldn't run, because the gemspec required
rake, which bundler install was trying to install.
