### PR TITLE
Add config option to disable emojis

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,11 +86,11 @@ class MyCoolPlugin < Repofetch::Plugin
     @arg_count = arg_count
   end
 
-  def self.from_git(git, args, _config)
+  def self.from_git(git, args)
     new(true, args.length)
   end
 
-  def self.from_args(args, _config)
+  def self.from_args(args)
     new(false, args.length)
   end
 

--- a/exe/repofetch
+++ b/exe/repofetch
@@ -4,13 +4,12 @@
 require 'git'
 require 'optparse'
 require 'repofetch'
-require 'repofetch/config'
 require 'repofetch/env'
 
 Repofetch::Env.load
-config = Repofetch::Config.load!
+Repofetch.load_config!
 
-config.plugins.each { |plugin| require plugin }
+Repofetch.config.plugins.each { |plugin| require plugin }
 
 options = {
   plugin: nil,
@@ -51,7 +50,7 @@ plugin_class = options[:plugin]
 # NOTE: If the user explicitly selected a plugin, then it is constructed from CLI args.
 # Otherwise, we try to build it from the repository.
 begin
-  plugin = plugin_class.nil? ? Repofetch.get_plugin(git, ARGV, config) : plugin_class.from_args(ARGV, config)
+  plugin = plugin_class.nil? ? Repofetch.get_plugin(git, ARGV) : plugin_class.from_args(ARGV)
 rescue ArgumentError => e
   warn e
   exit 1

--- a/lib/repofetch.rb
+++ b/lib/repofetch.rb
@@ -225,7 +225,9 @@ class Repofetch
     end
 
     def to_s
-      "#{@emoji || ''}#{@theme.nil? ? @label : @theme.format(:bold, @label)}: #{format_value}"
+      emoji = @emoji
+      emoji = nil unless Repofetch.config.nil? || Repofetch.config.emojis?
+      "#{emoji}#{@theme.nil? ? @label : @theme.format(:bold, @label)}: #{format_value}"
     end
 
     # Formats the value

--- a/lib/repofetch.rb
+++ b/lib/repofetch.rb
@@ -16,7 +16,18 @@ class Repofetch
   @plugins = []
 
   class << self
+    attr_accessor :config
     attr_reader :plugins
+  end
+
+  # Loads the config, without affecting the file system.
+  def self.load_config
+    @config = Config.load
+  end
+
+  # Loads the config, writing a default config if it doesn't exist.
+  def self.load_config!
+    @config = Config.load!
   end
 
   # Registers a plugin.
@@ -47,10 +58,9 @@ class Repofetch
   #
   # @param [String] git An instance of +Git::Base+
   # @param [Array<String>] args The arguments passed to the program.
-  # @param [Repofetch::Config] config The configuration to use.
   #
   # @returns [Plugin] A plugin to use.
-  def self.get_plugin(git, args, config)
+  def self.get_plugin(git, args)
     available_plugins = @plugins.filter do |plugin_class|
       plugin_class.matches_repo?(git)
     rescue NoMethodError
@@ -61,7 +71,7 @@ class Repofetch
 
     raise TooManyPluginsError if available_plugins.length > 1
 
-    available_plugins[0].from_git(git, args, config)
+    available_plugins[0].from_git(git, args)
   end
 
   # Gets the name of the default remote to use.
@@ -123,20 +133,18 @@ class Repofetch
     #
     # @param [Git::Base] _git The Git repository object to use when calling +Plugin.new+.
     # @param [Array] _args The arguments to process.
-    # @param [Config] _config The configuration loaded by the CLI.
     #
     # @returns [Plugin]
-    def self.from_git(_git, _args, _config)
+    def self.from_git(_git, _args)
       raise NoMethodError, 'from_git must be overridden by the plugin subclass'
     end
 
     # This will receive an array of strings (e.g. +ARGV+) and call +Plugin.new+.
     #
     # @param [Array] _args The arguments to process.
-    # @param [Config] _config The configuration loaded by the CLI.
     #
     # @returns [Plugin]
-    def self.from_args(_args, _config)
+    def self.from_args(_args)
       raise NoMethodError, 'from_args must be overridden by the plugin subclass'
     end
 

--- a/lib/repofetch/DEFAULT_CONFIG
+++ b/lib/repofetch/DEFAULT_CONFIG
@@ -2,3 +2,4 @@
 # vim: set ft=yaml:
 plugins:
   - 'repofetch/github'
+emojis: true

--- a/lib/repofetch/config.rb
+++ b/lib/repofetch/config.rb
@@ -33,6 +33,11 @@ class Repofetch
       @config[:plugins] || []
     end
 
+    # Should emojis be shown
+    def emojis?
+      @config[:emojis].nil? || @config[:emojis]
+    end
+
     def [](key)
       @config[key]
     end

--- a/lib/repofetch/config.rb
+++ b/lib/repofetch/config.rb
@@ -38,6 +38,10 @@ class Repofetch
       @config[:emojis].nil? || @config[:emojis]
     end
 
+    def emojis=(emojis)
+      @config[:emojis] = emojis
+    end
+
     def [](key)
       @config[key]
     end

--- a/lib/repofetch/config.rb
+++ b/lib/repofetch/config.rb
@@ -25,8 +25,8 @@ class Repofetch
     end
 
     # @param config_yaml [String] a YAML string
-    def initialize(config_yaml = DEFAULT_CONFIG)
-      @config = YAML.safe_load(config_yaml, symbolize_names: true)
+    def initialize(config_yaml = '')
+      @config = YAML.safe_load(config_yaml, symbolize_names: true) || {}
     end
 
     def plugins

--- a/lib/repofetch/github.rb
+++ b/lib/repofetch/github.rb
@@ -64,7 +64,7 @@ class Repofetch
     end
 
     # Creates an instance from a +Git::Base+ instance.
-    def self.from_git(git, args, _config)
+    def self.from_git(git, args)
       # TODO: Raise a better exception than ArgumentError
       raise ArgumentError, 'Explicitly activate this plugin to CLI arguments' unless args.empty?
 
@@ -74,7 +74,7 @@ class Repofetch
     end
 
     # Creates an instance from CLI args and configuration.
-    def self.from_args(args, _config)
+    def self.from_args(args)
       parser = OptionParser.new do |opts|
         opts.banner = 'Usage: <plugin activation> -- [options] OWNER/REPOSITORY'
         opts.separator ''

--- a/spec/repofetch/stat_spec.rb
+++ b/spec/repofetch/stat_spec.rb
@@ -3,6 +3,8 @@
 require 'repofetch'
 
 RSpec.describe Repofetch::Stat do
+  before { Repofetch.config = Repofetch::Config.new }
+
   describe '#format_value' do
     it "calls the value's to_s method" do
       stat = described_class.new('label', 'foo')
@@ -19,11 +21,23 @@ RSpec.describe Repofetch::Stat do
       end
     end
 
-    context 'when it has an emoji' do
+    context 'when it has an emoji and emojis are enabled' do
+      before { Repofetch.config.emojis = true }
+
       let(:stat) { described_class.new('spooky time', 'all the time', emoji: '👻') }
 
       it 'is in the format `<emoji><label>: <value>`' do
         expect(stat.to_s).to eq '👻spooky time: all the time'
+      end
+    end
+
+    context 'when it has an emoji but emojis are not enabled' do
+      before { Repofetch.config.emojis = false }
+
+      let(:stat) { described_class.new('spooky time', 'all the time', emoji: '👻') }
+
+      it 'is in the format `<emoji><label>: <value>`' do
+        expect(stat.to_s).to eq 'spooky time: all the time'
       end
     end
   end

--- a/spec/repofetch_spec.rb
+++ b/spec/repofetch_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Repofetch do
 
     context 'when no plugins match the repo' do
       it 'raises a NoPluginsError' do
-        expect { described_class.get_plugin(nil, nil, nil) }.to raise_error(described_class::NoPluginsError)
+        expect { described_class.get_plugin(nil, nil) }.to raise_error(described_class::NoPluginsError)
       end
     end
 
@@ -69,7 +69,7 @@ RSpec.describe Repofetch do
       end
 
       it 'raises a TooManyPluginsError' do
-        expect { described_class.get_plugin(nil, nil, nil) }.to raise_error(Repofetch::TooManyPluginsError)
+        expect { described_class.get_plugin(nil, nil) }.to raise_error(Repofetch::TooManyPluginsError)
       end
     end
 
@@ -89,7 +89,7 @@ RSpec.describe Repofetch do
       before { plugin.register }
 
       it 'returns an instance of that plugin' do
-        expect(described_class.get_plugin(nil, nil, nil).class).to be plugin
+        expect(described_class.get_plugin(nil, nil).class).to be plugin
       end
     end
 
@@ -114,7 +114,7 @@ RSpec.describe Repofetch do
 
       it 'generates a warning' do
         expect do
-          described_class.get_plugin(nil, nil, nil)
+          described_class.get_plugin(nil, nil)
         end.to output(/Does not implement \+matches_repo\?\+/).to_stderr
       end
     end


### PR DESCRIPTION
Emojis might not render well in other environments, so there should be a
simple way for the user to disable them. Preferably, in a way that plugins
can't (easily) ignore.

Resolves #208
