### PR TITLE
Revert "Deploy gem to GitHub Releases"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,16 +18,6 @@ jobs:
         with:
           prerelease: auto
 
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '2.7'
-      - run: gem build -o repofetch.gem repofetch.gemspec
-      - name: Upload Assets to Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.ref_name }} repofetch.gem
-
   # publish:
   #   name: Publish
   #   runs-on: ubuntu-latest

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,5 +1,1 @@
-0.4.2-rc.1
 
-## Other
-
-- Deploy built gem as GitHub release asset for each release


### PR DESCRIPTION
This might be an extra asset that's not really needed.

This reverts commit 669b0c9307322de3d94d16daaa7af1b6cf4af190.

## To do

- [ ] Delete asset from prerelease if this is merged
