### PR TITLE
Deprecate 2.7

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,2 +1,2 @@
-ARG VARIANT="2.7-buster"
+ARG VARIANT="3.0-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "dockerfile": "Dockerfile",
-    "args": { "VARIANT": "2.7-buster" }
+    "args": { "VARIANT": "3.0-bullseye" }
   },
   "extensions": [
     "EditorConfig.EditorConfig",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,10 @@ jobs:
           - macos-latest
           - windows-latest
         ruby-version:
-          - '2.7'
           - '3.0'
           - '3.1'
         exclude:
           # TODO: Figure out why Windows breaks on these
-          - os: windows-latest
-            ruby-version: '2.7'
           - os: windows-latest
             ruby-version: '3.0'
 
@@ -53,7 +50,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.0'
           bundler-cache: true
 
       - name: Check Style
@@ -68,7 +65,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.0'
           bundler-cache: true
 
       - name: Check Docs

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.0'
           bundler-cache: true
       - name: Build Docs
         run: bundle exec yardoc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.0'
       - run: bundle install
       - name: Set Up Credentials
         env:

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby2.7
+#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 #

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby2.7
+#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 #

--- a/lib/repofetch/github.rb
+++ b/lib/repofetch/github.rb
@@ -11,8 +11,8 @@ class Repofetch
   class Github < Repofetch::Plugin
     include ActionView::Helpers::NumberHelper
 
-    HTTP_REMOTE_REGEX = %r{https?://github\.com/(?<owner>[\w.-]+)/(?<repository>[\w.-]+)}.freeze
-    SSH_REMOTE_REGEX = %r{git@github\.com:(?<owner>[\w.-]+)/(?<repository>[\w.-]+)}.freeze
+    HTTP_REMOTE_REGEX = %r{https?://github\.com/(?<owner>[\w.-]+)/(?<repository>[\w.-]+)}
+    SSH_REMOTE_REGEX = %r{git@github\.com:(?<owner>[\w.-]+)/(?<repository>[\w.-]+)}
     ASCII = File.read(File.expand_path('github/ASCII', __dir__))
 
     attr_reader :owner, :repository

--- a/lib/repofetch/gitlab.rb
+++ b/lib/repofetch/gitlab.rb
@@ -8,8 +8,8 @@ require 'sawyer'
 class Repofetch
   # Adds support for GitLab repositories.
   class Gitlab < Repofetch::Plugin
-    HTTP_REMOTE_REGEX = %r{https?://gitlab\.com/(?<path>[\w.-][\w.\-/]+)}.freeze
-    SSH_REMOTE_REGEX = %r{git@gitlab\.com:(?<path>[\w.-][\w.\-/]+)}.freeze
+    HTTP_REMOTE_REGEX = %r{https?://gitlab\.com/(?<path>[\w.-][\w.\-/]+)}
+    SSH_REMOTE_REGEX = %r{git@gitlab\.com:(?<path>[\w.-][\w.\-/]+)}
     ASCII = File.read(File.expand_path('gitlab/ASCII', __dir__))
 
     attr_reader :repo_identifier

--- a/repofetch.gemspec
+++ b/repofetch.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage                           = 'https://github.com/spenserblack/repofetch'
   spec.license                            = 'MIT'
 
-  spec.required_ruby_version              = Gem::Requirement.new('>= 2.7.0')
+  spec.required_ruby_version              = Gem::Requirement.new('>= 3.0.0')
 
   spec.files                              = Dir['lib/**/*'] + Dir['exe/*'] + Dir['[A-Z]*']
 


### PR DESCRIPTION
Resolves #264

## To do checklist

- [ ] Update/create `RELEASE_NOTES` file if necessary

## Note

With some popular distros still using 2.7, this probably won't get merged for a *long* time.
