### PR TITLE
Fix Bitbucket Cloud repos never getting detected

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,1 +1,6 @@
+Bitbucket Cloud Bugfix
 
+## Fixed
+
+- Bitbucket Cloud not getting automatically detected when running `repofetch` in a
+  Bitbucket Cloud repository

--- a/lib/repofetch/bitbucketcloud.rb
+++ b/lib/repofetch/bitbucketcloud.rb
@@ -75,8 +75,15 @@ class Repofetch
       [match[:owner], match[:repo].delete_suffix('.git')]
     end
 
-    def self.from_git(*)
-      new
+    # Creates an instance from a +Git::Base+ instance.
+    #
+    # @raise [Repofetch::PluginUsageError] if this plugin was selected *and* arguments were passed.
+    def self.from_git(git, args)
+      raise Repofetch::PluginUsageError, 'Explicitly activate this plugin to CLI arguments' unless args.empty?
+
+      owner, repository = repo_identifiers(git)
+
+      new("#{owner}/#{repository}")
     end
 
     def self.from_args(args)

--- a/spec/repofetch/bitbucket_cloud_spec.rb
+++ b/spec/repofetch/bitbucket_cloud_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'repofetch/bitbucketcloud'
+
+RSpec.describe Repofetch::BitbucketCloud do
+  context 'when the remote is "http://bitbucket.org/foo/bar.git"' do
+    let(:remote) { 'http://bitbucket.org/foo/bar.git' }
+
+    describe '#matches_remote?' do
+      it 'is true' do
+        expect(described_class.matches_remote?(remote)).to be true
+      end
+    end
+
+    describe '#remote_identifiers' do
+      it 'returns ["foo", "bar"]' do
+        expect(described_class.remote_identifiers(remote)).to eq %w[foo bar]
+      end
+    end
+  end
+
+  context 'when the remote is "https://bitbucket.org/foo/bar.git"' do
+    let(:remote) { 'https://bitbucket.org/foo/bar.git' }
+
+    describe '#matches_remote?' do
+      it 'is true' do
+        expect(described_class.matches_remote?(remote)).to be true
+      end
+    end
+
+    describe '#remote_identifiers' do
+      it 'returns ["foo", "bar"]' do
+        expect(described_class.remote_identifiers(remote)).to eq %w[foo bar]
+      end
+    end
+  end
+
+  context 'when the remote is "http://bitbucket.org/foo/bar"' do
+    let(:remote) { 'http://bitbucket.org/foo/bar' }
+
+    describe '#matches_remote?' do
+      it 'is true' do
+        expect(described_class.matches_remote?(remote)).to be true
+      end
+    end
+
+    describe '#remote_identifiers' do
+      it 'returns ["foo", "bar"]' do
+        expect(described_class.remote_identifiers(remote)).to eq %w[foo bar]
+      end
+    end
+  end
+
+  context 'when the remote is "git@bitbucket.org:foo/bar.git"' do
+    let(:remote) { 'git@bitbucket.org:foo/bar.git' }
+
+    describe '#matches_remote?' do
+      it 'is true' do
+        expect(described_class.matches_remote?(remote)).to be true
+      end
+    end
+
+    describe '#remote_identifiers' do
+      it 'returns ["foo", "bar"]' do
+        expect(described_class.remote_identifiers(remote)).to eq %w[foo bar]
+      end
+    end
+  end
+
+  context 'when the remote is "git@bitbucket.org:foo/bar"' do
+    let(:remote) { 'git@bitbucket.org:foo/bar' }
+
+    describe '#matches_remote?' do
+      it 'is true' do
+        expect(described_class.matches_remote?(remote)).to be true
+      end
+    end
+
+    describe '#remote_identifiers' do
+      it 'returns ["foo", "bar"]' do
+        expect(described_class.remote_identifiers(remote)).to eq %w[foo bar]
+      end
+    end
+  end
+
+  context 'when the remote is "git@gitlab.com:foo/bar.git"' do
+    let(:remote) { 'git@gitlab.com:foo/bar.git' }
+
+    describe '#matches_remote?' do
+      it 'is true' do
+        expect(described_class.matches_remote?(remote)).to be false
+      end
+    end
+  end
+
+  context 'when the remote is "git@gitlab.com:foo/bar"' do
+    let(:remote) { 'git@gitlab.com:foo/bar' }
+
+    describe '#matches_remote?' do
+      it 'is false' do
+        expect(described_class.matches_remote?(remote)).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
This fixes a missing feature for the Bitbucket Cloud plugin that caused these repositories to *never* get automatically detected.

Fixes #270

## To do checklist

- [x] Update/create `RELEASE_NOTES` file if necessary
