### PR TITLE
Fix header separator length

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,1 +1,5 @@
+Next
 
+## Fixed
+
+- length of separator to match *visual* length of header

--- a/lib/repofetch.rb
+++ b/lib/repofetch.rb
@@ -174,7 +174,7 @@ class Repofetch
 
     # Creates the separator that appears underneath the header
     def separator
-      '-' * Repofetch::Util.clean_s(header).length
+      '-' * Repofetch::Util.clean_ansi(header).length
     end
 
     def to_s

--- a/lib/repofetch/util.rb
+++ b/lib/repofetch/util.rb
@@ -7,5 +7,10 @@ class Repofetch
     def self.clean_s(str)
       str.gsub(/%{[\w\d]+?}/, '')
     end
+
+    # Removes ANSI escape sequences from +str+.
+    def self.clean_ansi(str)
+      str.gsub("\e", '').gsub(/\[\d+(;\d+)*m/, '')
+    end
   end
 end

--- a/spec/repofetch/__snapshots__/repofetch_github_1.snap
+++ b/spec/repofetch/__snapshots__/repofetch_github_1.snap
@@ -1,5 +1,5 @@
             .ooOOOOOOOoo.            [0m        [1mghost/boo[0m @ [1mGitHub[0m
-        .oOOOOOOOOOOOOOOOOOo.        [0m        ----------------------------------
+        .oOOOOOOOOOOOOOOOOOo.        [0m        ------------------
      .oOOOOOOOOOOOOOOOOOOOOOOo.      [0m        🌐[1mHTTP(S)[0m: https://github.com/ghost/boo.git
    .oOOOOOOOOOOOOOOOOOOOOOOOOOOOo    [0m        🔑[1mSSH[0m: git@github.com:ghost/boo.git
   .OOOOO     OO-------OO     OOOOo   [0m        ⭐[1mstargazers[0m: 1

--- a/spec/repofetch/__snapshots__/repofetch_gitlab_1.snap
+++ b/spec/repofetch/__snapshots__/repofetch_gitlab_1.snap
@@ -1,5 +1,5 @@
 [31m          OOO                  OOO           [0m[1m[31mFoo / Bar[0m[0m @ [1m[31mGitLab[0m[0m
-[31m        OOOOOO                OOOOOO         [0m----------------------------------------------------
+[31m        OOOOOO                OOOOOO         [0m------------------
 [31m       OOOOOOOO              OOOOOOOO        [0m🌐[31m[1mHTTP(S)[0m[0m: https://gitlab.com/foo/bar.git
 [31m      OOOOOOOOOO            OOOOOOOOOO       [0m🔑[31m[1mSSH[0m[0m: git@gitlab.com:foo/bar.git
 [31m     OOOOOOOOOOOO          OOOOOOOOOOOO      [0m⭐[31m[1mstars[0m[0m: 1

--- a/spec/repofetch/__snapshots__/repofetch_gitlab_2.snap
+++ b/spec/repofetch/__snapshots__/repofetch_gitlab_2.snap
@@ -1,5 +1,5 @@
 [31m          OOO                  OOO           [0m[1m[31mFoo / Bar[0m[0m @ [1m[31mGitLab[0m[0m
-[31m        OOOOOO                OOOOOO         [0m----------------------------------------------------
+[31m        OOOOOO                OOOOOO         [0m------------------
 [31m       OOOOOOOO              OOOOOOOO        [0m🌐[31m[1mHTTP(S)[0m[0m: https://gitlab.com/foo/bar.git
 [31m      OOOOOOOOOO            OOOOOOOOOO       [0m🔑[31m[1mSSH[0m[0m: git@gitlab.com:foo/bar.git
 [31m     OOOOOOOOOOOO          OOOOOOOOOOOO      [0m⭐[31m[1mstars[0m[0m: 1


### PR DESCRIPTION
Makes the separator have the same visual length as the header.

Fixes #274

## To do checklist

- [x] Update/create `RELEASE_NOTES` file if necessary
