### PR TITLE
Support plugins using paths

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -4,6 +4,8 @@ Next
 
 - `Stat#format(theme)` to create styled stats
 - `Stat#style_label` to style the label without mutating the original `Stat` instance
+- `Plugin#matches_path?` and `Plugin#from_path` to allow plugins to initialize from paths, not
+  just git repositories
 
 ## Changed
 

--- a/lib/repofetch/cli.rb
+++ b/lib/repofetch/cli.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'git'
 require 'optparse'
 require 'repofetch'
 require 'repofetch/config'
@@ -56,8 +55,7 @@ class Repofetch
     def new_plugin
       return @plugin.from_args(@args) unless @plugin.nil?
 
-      git = Git.open(@repository_path)
-      Repofetch.get_plugin(git, @args)
+      Repofetch.get_plugin(@repository_path, @args)
     end
 
     private

--- a/lib/repofetch/plugin.rb
+++ b/lib/repofetch/plugin.rb
@@ -36,6 +36,16 @@ class Repofetch
       false
     end
 
+    # @abstract Detects that this plugin should be used. Should be overridden by subclasses.
+    #
+    # This is intended to be more generic than +matches_repo?+, and support any path.
+    #
+    # An example implementation is checking if an expected file exists in this path.
+    # @param [String] _path The path to check
+    def self.matches_path?(_path)
+      false
+    end
+
     # @abstract This should use a git instance and call +Plugin.new+.
     #
     # @param [Git::Base] _git The Git repository object to use when calling +Plugin.new+.

--- a/lib/repofetch/plugin.rb
+++ b/lib/repofetch/plugin.rb
@@ -56,6 +56,16 @@ class Repofetch
       raise NoMethodError, 'from_git must be overridden by the plugin subclass'
     end
 
+    # @abstract This should use a path and call +Plugin.new+.
+    #
+    # @param [String] _path The path to use when calling +Plugin.new+.
+    # @param [Array] _args The arguments to process.
+    #
+    # @return [Plugin]
+    def self.from_path(_path, _args)
+      raise NoMethodError, 'from_path must be overridden by the plugin subclass'
+    end
+
     # @abstract This will receive an array of strings (e.g. +ARGV+) and call +Plugin.new+.
     #
     # @param [Array] _args The arguments to process.

--- a/spec/repofetch/plugin_spec.rb
+++ b/spec/repofetch/plugin_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe Repofetch::Plugin do
     end
   end
 
+  describe '#matches_path?' do
+    it 'returns false' do
+      expect(described_class.matches_path?(nil)).to be false
+    end
+  end
+
   describe '#from_git' do
     it 'raises a NoMethodError' do
       expect { described_class.from_git(nil, nil) }.to raise_error(NoMethodError)

--- a/spec/repofetch/plugin_spec.rb
+++ b/spec/repofetch/plugin_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe Repofetch::Plugin do
     end
   end
 
+  describe '#from_path' do
+    it 'raises a NoMethodError' do
+      expect { described_class.from_path(nil, nil) }.to raise_error(NoMethodError)
+    end
+  end
+
   describe '#from_args' do
     it 'raises a NoMethodError' do
       expect { described_class.from_args(nil) }.to raise_error(NoMethodError)

--- a/spec/repofetch_spec.rb
+++ b/spec/repofetch_spec.rb
@@ -95,6 +95,16 @@ RSpec.describe Repofetch do
     end
   end
 
+  describe '#get_plugins_for_repo' do
+    context 'when the repository cannot be opened/found' do
+      before { allow(Git).to receive(:open).and_raise(ArgumentError) }
+
+      it 'returns an empty array' do
+        expect(described_class.get_plugins_for_repo('foo')).to eq []
+      end
+    end
+  end
+
   describe Repofetch::Plugin, '#register' do
     before { Repofetch.send(:clear_plugins) }
 


### PR DESCRIPTION
This makes it possible to write a plugin that uses a path, but not a git repository. For example, #253.

Resolves #254

## To do checklist

- [x] Update/create `RELEASE_NOTES` file if necessary
